### PR TITLE
Add iOS UIScene Lifecycle Support & Update Meta SDK Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 2.2.0
+
+* iOS: Adopted Apple's `UIScene` lifecycle ([Flutter migration guide](https://docs.flutter.dev/release/breaking-changes/uiscenedelegate#migration-guide-for-flutter-plugins)).
+  * Plugin now conforms to `FlutterSceneLifeCycleDelegate` and is registered via `addSceneDelegate` in addition to `addApplicationDelegate`, so it works on hosts whether or not they have migrated to `UIScene`.
+  * Captures launch URL info from `scene(_:willConnectTo:options:)` and forwards `scene(_:openURLContexts:)` to the Meta SDK (replacing the legacy `application(_:open:options:)` path on UIScene-based apps).
+  * Forwards Universal Links to the Meta SDK from both `application(_:continue:restorationHandler:)` and `scene(_:continue:)` automatically (no AppDelegate changes required).
+* Bumped minimum Flutter constraint to `>=3.38.0` (required for `FlutterSceneLifeCycleDelegate` / `addSceneDelegate`).
+
 ### 2.1.0+1
 
 * Update readme (thanks @ltOgt)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Plugin now conforms to `FlutterSceneLifeCycleDelegate` and is registered via `addSceneDelegate` in addition to `addApplicationDelegate`, so it works on hosts whether or not they have migrated to `UIScene`.
   * Captures launch URL info from `scene(_:willConnectTo:options:)` and forwards `scene(_:openURLContexts:)` to the Meta SDK (replacing the legacy `application(_:open:options:)` path on UIScene-based apps).
   * Forwards Universal Links to the Meta SDK from both `application(_:continue:restorationHandler:)` and `scene(_:continue:)` automatically (no AppDelegate changes required).
+* iOS: URL opens that occur **after** `initSdk()` are now forwarded to `FBSDKCoreKit.ApplicationDelegate` immediately (previously only the launch URL was delivered, so attribution-related custom-scheme opens during a running session were dropped). All `UIOpenURLContext` entries delivered in a single `scene(_:openURLContexts:)` call are now processed (previously only the first was used).
 * Bumped minimum Flutter constraint to `>=3.38.0` (required for `FlutterSceneLifeCycleDelegate` / `addSceneDelegate`).
 * Bumped Meta SDK versions:
   * Android: Facebook SDK 18.1.3 → 18.2.3 (thread-safety fixes in `FetchedAppGateKeepersManager`/`AttributionIdentifiers`, `SecureRandom` replaces `java.util.Random`, deprecated `CookieSyncManager` removed, `Build.VERSION.SDK_INT` guard before AdServices APIs, deep link referrer support). No public API changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   * Captures launch URL info from `scene(_:willConnectTo:options:)` and forwards `scene(_:openURLContexts:)` to the Meta SDK (replacing the legacy `application(_:open:options:)` path on UIScene-based apps).
   * Forwards Universal Links to the Meta SDK from both `application(_:continue:restorationHandler:)` and `scene(_:continue:)` automatically (no AppDelegate changes required).
 * Bumped minimum Flutter constraint to `>=3.38.0` (required for `FlutterSceneLifeCycleDelegate` / `addSceneDelegate`).
+* Bumped Meta SDK versions:
+  * Android: Facebook SDK 18.1.3 → 18.2.3 (thread-safety fixes in `FetchedAppGateKeepersManager`/`AttributionIdentifiers`, `SecureRandom` replaces `java.util.Random`, deprecated `CookieSyncManager` removed, `Build.VERSION.SDK_INT` guard before AdServices APIs, deep link referrer support). No public API changes.
+  * iOS: FBSDKCoreKit 18.0.1 → 18.0.3 (reintroduced fast app switching in 18.0.2, anonymous deferral deeplink support in 18.0.3). No public API changes.
 
 ### 2.1.0+1
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ Compare the info box under https://developers.facebook.com/docs/app-events/gdpr-
 * **Android**: Facebook SDK 18.1.3
 * **iOS**: FBSDKCoreKit 18.0.1
 
+### iOS UIScene lifecycle
+
+Starting with `2.2.0`, the iOS plugin adopts Apple's `UIScene` lifecycle and registers itself as both an application delegate and a scene delegate. No `AppDelegate` or `SceneDelegate` changes are required on your side: the plugin auto-forwards URL openings (custom URL schemes) and Universal Links (`NSUserActivity`) to the Meta SDK on both the legacy `UIApplicationDelegate` path and the new `UISceneDelegate` path.
+
+This requires Flutter `>=3.38.0`. See the [Flutter UISceneDelegate adoption guide](https://docs.flutter.dev/release/breaking-changes/uiscenedelegate) for context.
 
 ### About Meta SDK
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Compare the info box under https://developers.facebook.com/docs/app-events/gdpr-
 
 ### SDK Versions
 
-* **Android**: Facebook SDK 18.1.3
-* **iOS**: FBSDKCoreKit 18.0.1
+* **Android**: Facebook SDK 18.2.3
+* **iOS**: FBSDKCoreKit 18.0.3
 
 ### iOS UIScene lifecycle
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ android {
     }
 
     dependencies {
-        implementation("com.facebook.android:facebook-android-sdk:18.1.3")
+        implementation("com.facebook.android:facebook-android-sdk:18.2.3")
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.0.0")
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - FBAEMKit (18.0.1):
-    - FBSDKCoreKit_Basics (= 18.0.1)
-  - FBSDKCoreKit (18.0.1):
-    - FBAEMKit (= 18.0.1)
-    - FBSDKCoreKit_Basics (= 18.0.1)
-  - FBSDKCoreKit_Basics (18.0.1)
+  - FBAEMKit (18.0.3):
+    - FBSDKCoreKit_Basics (= 18.0.3)
+  - FBSDKCoreKit (18.0.3):
+    - FBAEMKit (= 18.0.3)
+    - FBSDKCoreKit_Basics (= 18.0.3)
+  - FBSDKCoreKit_Basics (18.0.3)
   - Flutter (1.0.0)
   - flutter_meta_appads_sdk (0.0.1):
-    - FBSDKCoreKit (~> 18.0.1)
+    - FBSDKCoreKit (~> 18.0.3)
     - Flutter
   - integration_test (0.0.1):
     - Flutter
@@ -32,12 +32,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  FBAEMKit: b2ed182002dbcb65d5a60059c9693d322186cd00
-  FBSDKCoreKit: 7f96852f2539bdb88ba8d47e5ab4ae70a6f8d691
-  FBSDKCoreKit_Basics: 22d4c1a509ded4e45116f3bb167a14907550f62e
+  FBAEMKit: 2a6b529993713c185b02bc36f8c91129bf78dfb0
+  FBSDKCoreKit: 65d7f7a7d6fcc3aa6eb6e093ec737a4184fc6049
+  FBSDKCoreKit_Basics: 7bc9d8fde8f70985fba2ed7c1d07e319f969a991
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_meta_appads_sdk: fd3996b95dfc473e4a8c378c10e094a18c74b1f1
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  flutter_meta_appads_sdk: 17fac193997d817f43cda96b21f397392a2f355e
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
 
 PODFILE CHECKSUM: 4f1c12611da7338d21589c0b2ecd6bd20b109694
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -141,26 +141,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -279,5 +279,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.9.0-0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/example_spm/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example_spm/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/facebook/facebook-ios-sdk.git",
       "state" : {
-        "revision" : "a77ba210bf6534564ad4027fce2fef65babfadf8",
-        "version" : "18.0.1"
+        "revision" : "8c90832bf2302d9ecd0d23cb63b81f1fb9a36497",
+        "version" : "18.0.3"
       }
     }
   ],

--- a/example_spm/pubspec.lock
+++ b/example_spm/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -89,7 +89,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.1+1"
+    version: "2.1.0+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -141,26 +141,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -279,5 +279,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.9.0-0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/ios/flutter_meta_appads_sdk.podspec
+++ b/ios/flutter_meta_appads_sdk.podspec
@@ -14,7 +14,7 @@ Meta SDK for Flutter. This package allow you to integration with Facebook SDK us
 
 
   s.dependency 'Flutter'
-  s.dependency 'FBSDKCoreKit', '~> 18.0.1'
+  s.dependency 'FBSDKCoreKit', '~> 18.0.3'
 
   s.platform = :ios, '13.0'
 

--- a/ios/flutter_meta_appads_sdk/Package.swift
+++ b/ios/flutter_meta_appads_sdk/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/facebook/facebook-ios-sdk.git", from: "18.0.1")
+        .package(url: "https://github.com/facebook/facebook-ios-sdk.git", from: "18.0.3")
     ],
     targets: [
         .target(

--- a/ios/flutter_meta_appads_sdk/Sources/flutter_meta_appads_sdk/FlutterMetaAppadsSdkPlugin.swift
+++ b/ios/flutter_meta_appads_sdk/Sources/flutter_meta_appads_sdk/FlutterMetaAppadsSdkPlugin.swift
@@ -2,30 +2,97 @@ import FBSDKCoreKit
 import Flutter
 import UIKit
 
-public class FlutterMetaAppadsSdkPlugin: NSObject, FlutterPlugin, FlutterMetaAppadsSdkHostApi {
+public class FlutterMetaAppadsSdkPlugin: NSObject, FlutterPlugin, FlutterSceneLifeCycleDelegate, FlutterMetaAppadsSdkHostApi {
     public static func register(with registrar: FlutterPluginRegistrar) {
         let instance = FlutterMetaAppadsSdkPlugin()
         
         FlutterMetaAppadsSdkHostApiSetup.setUp(binaryMessenger: registrar.messenger(), api: instance)
         
+        // Register for both AppDelegate and SceneDelegate callbacks so the
+        // plugin keeps working on apps that have not yet adopted the
+        // UIScene lifecycle as well as those that have.
         registrar.addApplicationDelegate(instance)
+        registrar.addSceneDelegate(instance)
     }
 
     private var startUpApplication: UIApplication?
     private var startUpURL: URL?
-    private var startUpOptions: [UIApplication.OpenURLOptionsKey: Any]?
+    private var startUpSourceApplication: String?
+    private var startUpAnnotation: Any?
     private var loggingEnabled: Bool = false
+
+    // MARK: - UIApplicationDelegate (legacy, pre-UIScene lifecycle)
 
     public func application(
         _ application: UIApplication,
         open url: URL,
         options: [UIApplication.OpenURLOptionsKey: Any] = [:]
     ) -> Bool {
-        startUpApplication = application
-        startUpURL = url
-        startUpOptions = options
+        captureStartUp(
+            url: url,
+            sourceApplication: options[.sourceApplication] as? String,
+            annotation: options[.annotation]
+        )
 
         return false
+    }
+
+    public func application(
+        _ application: UIApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+    ) -> Bool {
+        ApplicationDelegate.shared.application(application, continue: userActivity)
+
+        // Don't short-circuit other handlers (e.g. Flutter's deep-link router).
+        return false
+    }
+
+    // MARK: - FlutterSceneLifeCycleDelegate (UIScene lifecycle)
+
+    public func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions?
+    ) -> Bool {
+        if let context = connectionOptions?.urlContexts.first {
+            captureStartUp(
+                url: context.url,
+                sourceApplication: context.options.sourceApplication,
+                annotation: context.options.annotation
+            )
+        }
+
+        return false
+    }
+
+    public func scene(
+        _ scene: UIScene,
+        openURLContexts URLContexts: Set<UIOpenURLContext>
+    ) -> Bool {
+        if let context = URLContexts.first {
+            captureStartUp(
+                url: context.url,
+                sourceApplication: context.options.sourceApplication,
+                annotation: context.options.annotation
+            )
+        }
+
+        return false
+    }
+
+    public func scene(_ scene: UIScene, continue userActivity: NSUserActivity) -> Bool {
+        ApplicationDelegate.shared.application(UIApplication.shared, continue: userActivity)
+
+        // Don't short-circuit other handlers (e.g. Flutter's deep-link router).
+        return false
+    }
+
+    private func captureStartUp(url: URL, sourceApplication: String?, annotation: Any?) {
+        startUpApplication = UIApplication.shared
+        startUpURL = url
+        startUpSourceApplication = sourceApplication
+        startUpAnnotation = annotation
     }
 
     // MARK: - FlutterMetaAppadsSdkHostApi Implementation
@@ -94,13 +161,12 @@ public class FlutterMetaAppadsSdkPlugin: NSObject, FlutterPlugin, FlutterMetaApp
         }
 
         if let application = startUpApplication,
-           let url = startUpURL,
-           let options = startUpOptions {
+           let url = startUpURL {
             ApplicationDelegate.shared.application(
                 application,
                 open: url,
-                sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
-                annotation: options[UIApplication.OpenURLOptionsKey.annotation]
+                sourceApplication: startUpSourceApplication,
+                annotation: startUpAnnotation as Any
             )
         } else {
             ApplicationDelegate.shared.initializeSDK()

--- a/ios/flutter_meta_appads_sdk/Sources/flutter_meta_appads_sdk/FlutterMetaAppadsSdkPlugin.swift
+++ b/ios/flutter_meta_appads_sdk/Sources/flutter_meta_appads_sdk/FlutterMetaAppadsSdkPlugin.swift
@@ -20,6 +20,7 @@ public class FlutterMetaAppadsSdkPlugin: NSObject, FlutterPlugin, FlutterSceneLi
     private var startUpSourceApplication: String?
     private var startUpAnnotation: Any?
     private var loggingEnabled: Bool = false
+    private var sdkInitialized: Bool = false
 
     // MARK: - UIApplicationDelegate (legacy, pre-UIScene lifecycle)
 
@@ -28,12 +29,17 @@ public class FlutterMetaAppadsSdkPlugin: NSObject, FlutterPlugin, FlutterSceneLi
         open url: URL,
         options: [UIApplication.OpenURLOptionsKey: Any] = [:]
     ) -> Bool {
-        captureStartUp(
+        let sourceApplication = options[.sourceApplication] as? String
+        let annotation = options[.annotation]
+
+        forwardOpenURL(
+            application: application,
             url: url,
-            sourceApplication: options[.sourceApplication] as? String,
-            annotation: options[.annotation]
+            sourceApplication: sourceApplication,
+            annotation: annotation
         )
 
+        // Don't short-circuit other handlers (e.g. Flutter's deep-link router).
         return false
     }
 
@@ -55,12 +61,8 @@ public class FlutterMetaAppadsSdkPlugin: NSObject, FlutterPlugin, FlutterSceneLi
         willConnectTo session: UISceneSession,
         options connectionOptions: UIScene.ConnectionOptions?
     ) -> Bool {
-        if let context = connectionOptions?.urlContexts.first {
-            captureStartUp(
-                url: context.url,
-                sourceApplication: context.options.sourceApplication,
-                annotation: context.options.annotation
-            )
+        if let contexts = connectionOptions?.urlContexts {
+            forwardURLContexts(contexts)
         }
 
         return false
@@ -70,13 +72,7 @@ public class FlutterMetaAppadsSdkPlugin: NSObject, FlutterPlugin, FlutterSceneLi
         _ scene: UIScene,
         openURLContexts URLContexts: Set<UIOpenURLContext>
     ) -> Bool {
-        if let context = URLContexts.first {
-            captureStartUp(
-                url: context.url,
-                sourceApplication: context.options.sourceApplication,
-                annotation: context.options.annotation
-            )
-        }
+        forwardURLContexts(URLContexts)
 
         return false
     }
@@ -93,6 +89,45 @@ public class FlutterMetaAppadsSdkPlugin: NSObject, FlutterPlugin, FlutterSceneLi
         startUpURL = url
         startUpSourceApplication = sourceApplication
         startUpAnnotation = annotation
+    }
+
+    private func forwardOpenURL(
+        application: UIApplication,
+        url: URL,
+        sourceApplication: String?,
+        annotation: Any?
+    ) {
+        if sdkInitialized {
+            ApplicationDelegate.shared.application(
+                application,
+                open: url,
+                sourceApplication: sourceApplication,
+                annotation: annotation as Any
+            )
+        } else {
+            // Defer to initSdk() so the SDK can record the launch URL once it
+            // is initialized by Dart code.
+            captureStartUp(
+                url: url,
+                sourceApplication: sourceApplication,
+                annotation: annotation
+            )
+        }
+    }
+
+    private func forwardURLContexts(_ contexts: Set<UIOpenURLContext>) {
+        guard !contexts.isEmpty else { return }
+
+        let application = UIApplication.shared
+
+        for context in contexts {
+            forwardOpenURL(
+                application: application,
+                url: context.url,
+                sourceApplication: context.options.sourceApplication,
+                annotation: context.options.annotation
+            )
+        }
     }
 
     // MARK: - FlutterMetaAppadsSdkHostApi Implementation
@@ -171,6 +206,12 @@ public class FlutterMetaAppadsSdkPlugin: NSObject, FlutterPlugin, FlutterSceneLi
         } else {
             ApplicationDelegate.shared.initializeSDK()
         }
+
+        sdkInitialized = true
+        startUpApplication = nil
+        startUpURL = nil
+        startUpSourceApplication = nil
+        startUpAnnotation = nil
 
         if loggingEnabled {
             print("FBSDKLog: SDK Version: \(Settings.shared.sdkVersion)")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: flutter_meta_appads_sdk
 description: "This Flutter plugin provides a simple interface to interact with the Meta SDK. It allows you to initialize the SDK, set user data (Advanced Attribution), and log events/purchases."
-version: 2.1.0+1
+version: 2.2.0
 homepage: https://github.com/sdurban/flutter_meta_appads_sdk
 repository: https://github.com/sdurban/flutter_meta_appads_sdk
 
 environment:
   sdk: ^3.4.0
-  flutter: '>=3.3.0'
+  flutter: '>=3.38.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
This PR introduces the following improvements:

1. **Adopted iOS `UIScene` Lifecycle**
   - The plugin now conforms to `FlutterSceneLifeCycleDelegate` and registers itself via `addSceneDelegate` in addition to `addApplicationDelegate`, so it works on hosts whether or not they have migrated to `UIScene`.
   - Captures launch URL info from `scene(_:willConnectTo:options:)` and forwards `scene(_:openURLContexts:)` to the Meta SDK (replacing the legacy `application(_:open:options:)` path on UIScene-based apps).
   - Forwards Universal Links to the Meta SDK from both `application(_:continue:restorationHandler:)` and `scene(_:continue:)` automatically (no `AppDelegate` / `SceneDelegate` changes required).
   - Follows the official [Flutter UISceneDelegate adoption guide](https://docs.flutter.dev/release/breaking-changes/uiscenedelegate) and the [Flutter plugin migration guide](https://docs.flutter.dev/release/breaking-changes/uiscenedelegate#migration-guide-for-flutter-plugins).
   - Bumped minimum Flutter constraint to `>=3.38.0` (required for `FlutterSceneLifeCycleDelegate` / `addSceneDelegate`).

2. **Updated Facebook SDK to the Latest Versions**
   - **Android:** `com.facebook.android:facebook-android-sdk` `18.1.3` → `18.2.3`
     - Thread-safety fixes in `FetchedAppGateKeepersManager` / `AttributionIdentifiers`.
     - `SecureRandom` replaces `java.util.Random`.
     - Deprecated `CookieSyncManager` removed.
     - `Build.VERSION.SDK_INT` guard added before AdServices APIs.
     - Deep link referrer support.
     - No public API changes.
   - **iOS:** `FBSDKCoreKit` `18.0.1` → `18.0.3` (both CocoaPods podspec and Swift Package Manager `Package.swift`)
     - Reintroduced fast app switching in 18.0.2.
     - Anonymous deferral deeplink support in 18.0.3.
     - No public API changes.
   - Bumped plugin version `2.1.0+1` → `2.2.0`.

## Why These Changes?

### **iOS UIScene Lifecycle Adoption**
- Required for compatibility with apps migrating to Apple's `UIScene` lifecycle (now the default for Flutter `>=3.38.0`).
- Without scene-delegate participation, attribution-critical events such as deferred deep link openings and Universal Links would be missed on UIScene-based hosts, breaking Meta install/event attribution.
- The implementation gracefully supports both legacy `UIApplicationDelegate` and new `UISceneDelegate` paths, so integrators do not need to change their `AppDelegate` or add a `SceneDelegate`.

### **Facebook SDK Update**
- Keeps the plugin aligned with the latest Meta SDK improvements.
- Enhances stability, thread-safety, performance, and security on Android.
- Restores fast app switching and improves deferred deep link attribution on iOS.